### PR TITLE
Fix typo preventing link to be parsed

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -225,7 +225,7 @@ automatically changed to ``'.inner'``):
 
 .. note::
 
-    All custom :ref:`service tags </service_container/tags>`_ from the decorated
+    All custom :ref:`service tags </service_container/tags>` from the decorated
     service are removed in the new service. Only certain built-in service tags
     defined by Symfony are retained: ``container.service_locator``, ``container.service_subscriber``,
     ``kernel.event_subscriber``, ``kernel.event_listener``, ``kernel.locale_aware``,


### PR DESCRIPTION
The documentation website displays a commit hash, instead of the link to the tags section : 
https://symfony.com/doc/6.4/service_container/service_decoration.html

I did not fount this issue prior to 6.4